### PR TITLE
Fix multiple system packages installation

### DIFF
--- a/dockerfiles/run-test.sh
+++ b/dockerfiles/run-test.sh
@@ -126,6 +126,20 @@ for test_gem_path in "${test_gem_paths[@]}"; do
   group_begin "Test: ${gem_name}: Default"
   # Must be succeeded
   gem install "${gem_install_options[@]}" ./*.gem
+  if [ "${gem_name}" = "dummy-cairo" ]; then
+    if [ -n "${CONDA_PREFIX:-}" ]; then
+      conda list cairo
+      conda list expat
+      conda list xorg-kbproto
+      conda list xorg-libxau
+      conda list xorg-libxext
+      conda list xorg-libxrender
+      conda list xorg-renderproto
+      conda list xorg-xextproto
+      conda list xorg-xproto
+      conda list zlib
+    fi
+  fi
   if [ "${gem_name}" = "dummy-graphviz" ]; then
     ruby -e 'require "dummy-graphviz"'
   fi

--- a/lib/rubygems-requirements-system/platform/base.rb
+++ b/lib/rubygems-requirements-system/platform/base.rb
@@ -45,7 +45,7 @@ module RubyGemsRequirementsSystem
 
       def install(requirement)
         synchronize do
-          requirement.system_packages.any? do |package|
+          requirement.system_packages.all? do |package|
             install_package(package) and requirement.satisfied?
           end
         end


### PR DESCRIPTION
Hello,

I found we cannot install multiple packages. For instance, in Conda environment (continuumio/miniconda3 image), installation of cairo gem succeeds but load fails:

```
# irb
irb(main):001> require "cairo"
<internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require': libcairo.so.2: cannot open shared object file: No such file or directory - /var/lib/gems/3.3.0/gems/cairo-1.18.5/lib/cairo.so (LoadError)
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
        from /var/lib/gems/3.3.0/gems/cairo-1.18.5/lib/cairo.rb:24:in `<top (required)>'
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:141:in `require'
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:141:in `rescue in require'
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:135:in `require'
        from (irb):1:in `<main>'
        from <internal:kernel>:187:in `loop'
        from /usr/lib/ruby/gems/3.3.0/gems/irb-1.13.1/exe/irb:9:in `<top (required)>'
        from /usr/bin/irb:25:in `load'
        from /usr/bin/irb:25:in `<main>'
<internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- cairo (LoadError)
        from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:136:in `require'
        from (irb):1:in `<main>'
        from /usr/lib/ruby/3.3.0/irb/workspace.rb:121:in `eval'
        from /usr/lib/ruby/3.3.0/irb/workspace.rb:121:in `evaluate'
        from /usr/lib/ruby/3.3.0/irb/context.rb:633:in `evaluate_expression'
        from /usr/lib/ruby/3.3.0/irb/context.rb:600:in `evaluate'
        from /usr/lib/ruby/3.3.0/irb.rb:1049:in `block (2 levels) in eval_input'
        from /usr/lib/ruby/3.3.0/irb.rb:1380:in `signal_status'
        from /usr/lib/ruby/3.3.0/irb.rb:1041:in `block in eval_input'
        from /usr/lib/ruby/3.3.0/irb.rb:1120:in `block in each_top_level_statement'
        from <internal:kernel>:187:in `loop'
        from /usr/lib/ruby/3.3.0/irb.rb:1117:in `each_top_level_statement'
        from /usr/lib/ruby/3.3.0/irb.rb:1040:in `eval_input'
        from /usr/lib/ruby/3.3.0/irb.rb:1021:in `block in run'
        from /usr/lib/ruby/3.3.0/irb.rb:1020:in `catch'
        from /usr/lib/ruby/3.3.0/irb.rb:1020:in `run'
        ... 4 levels...
irb(main):002> Cairo
=> Cairo
irb(main):003> Cairo::BUILD_VERSION
(irb):3:in `<main>': uninitialized constant Cairo::BUILD_VERSION (NameError)

Cairo::BUILD_VERSION
     ^^^^^^^^^^^^^^^
Did you mean?  RUBY_VERSION
        from <internal:kernel>:187:in `loop'
        from /usr/lib/ruby/gems/3.3.0/gems/irb-1.13.1/exe/irb:9:in `<top (required)>'
        from /usr/bin/irb:25:in `load'
        from /usr/bin/irb:25:in `<main>'
```

I fixed this issue.

My motivation is to install both GStreamer and its audio library (and possibly video library in the future) for https://github.com/ruby-gnome/ruby-gnome/pull/1704

Thank you.