### PR TITLE
Fix port command option

### DIFF
--- a/lib/rubygems-requirements-system/platform/macports.rb
+++ b/lib/rubygems-requirements-system/platform/macports.rb
@@ -32,7 +32,7 @@ module RubyGemsRequirementsSystem
 
       private
       def install_command_line(package)
-        ["port", "install", "-y", package]
+        ["port", "install", "-N", package]
       end
 
       def need_super_user_priviledge?


### PR DESCRIPTION
Hello,

This pull request fixes option of MacPorts' `port` command. `-y` is for dry-run and `-N` is non-interactive.

refs: https://man.macports.org/port.1.html

Thank you.